### PR TITLE
Change lowercase 'x' to uppercase 'X' for consistency with directory name so that installation succeeds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 from distutils.core import setup
 import setuptools
 setup(
-    name='shell_analysis_fenicsx',
+    name='shell_analysis_fenicsX',
     version='0.1',
     packages=[
-        'shell_analysis_fenicsx'
+        'shell_analysis_fenicsX'
     ],
     url='https://github.com/RuruX/shell-analysis-fenicsx',
     author='Ru Xiang',


### PR DESCRIPTION
Fix as suggested in issue #1